### PR TITLE
fix: allow top navigation in iframe overlay

### DIFF
--- a/packages/embedded-connection-journey/src/iframe-overlay.ts
+++ b/packages/embedded-connection-journey/src/iframe-overlay.ts
@@ -289,6 +289,7 @@ export class IframeOverlay {
             'allow-forms',
             'allow-popups',
             'allow-popups-to-escape-sandbox',
+            'allow-top-navigation',
             'allow-top-navigation-by-user-activation',
             'allow-modals',
             'allow-storage-access-by-user-activation',


### PR DESCRIPTION
DATA1-2784

Added 'allow-top-navigation' to the iframe sandbox attributes to enhance navigation capabilities for all browsers.
