### PR TITLE
fix: defer iframe load until journey.start() is called

### DIFF
--- a/packages/embedded-connection-journey/src/iframe-overlay.ts
+++ b/packages/embedded-connection-journey/src/iframe-overlay.ts
@@ -103,6 +103,7 @@ export class IframeOverlay {
     private isVisible = false;
     private bodyScrollStyle = document.body.style.overflow;
     private animationStyle: HTMLStyleElement | null = null;
+    private pendingSrc: string | null = null;
 
     /**
      * Create the overlay and iframe elements with loading spinner
@@ -154,6 +155,7 @@ export class IframeOverlay {
             },
         };
 
+        this.pendingSrc = iframeConfig.src;
         this.configureIframe(iframeConfig);
 
         this.container.appendChild(this.iframe);
@@ -164,6 +166,20 @@ export class IframeOverlay {
 
         // Add overlay to document
         document.body.appendChild(this.overlay);
+    }
+
+    /**
+     * Load the connection URL into the iframe, triggering the actual network request.
+     * Deferred until the journey is explicitly started so createJourney() alone never
+     * consumes the single-use connection token.
+     */
+    load(): void {
+        if (!this.iframe || !this.pendingSrc) {
+            return;
+        }
+
+        this.iframe.src = this.pendingSrc;
+        this.pendingSrc = null;
     }
 
     /**
@@ -312,7 +328,7 @@ export class IframeOverlay {
         }
 
         this.iframe.id = config.id;
-        this.iframe.src = config.src;
+        // src intentionally not set here — deferred to load(), triggered by Journey.start()
         this.iframe.title = config.title;
         this.iframe.setAttribute('data-session-id', config['data-session-id']);
         this.iframe.sandbox.value = config.sandbox.join(' ');

--- a/packages/embedded-connection-journey/src/journey.ts
+++ b/packages/embedded-connection-journey/src/journey.ts
@@ -70,6 +70,9 @@ export class Journey implements JourneyInstance {
         }
 
         try {
+            // Load the connection URL into the iframe now that the journey is actually starting
+            this.overlay.load();
+
             // Show the overlay with loading spinner
             this.overlay.show();
 


### PR DESCRIPTION
[DATA1-3661](https://clearscore.atlassian.net/browse/DATA1-3661)

### Summary

`createJourney()` triggered a real network load of the connection URL immediately on construction, instead of waiting for `journey.start()`. Any consumer calling `createJourney()` ahead of actual user intent (e.g. preparing it early, or recreating it on re-render without memoizing) silently burned a single-use `partnerToken` and generated a full page load on the connection journey, with no user action.

Confirmed via an Amplitude cohort showing a partner's embedded iframe loading the connection-one-web providers page multiple times within seconds, each with a distinct `partnerToken`, recurring roughly every ~15 minutes — while connection-one-web itself has no polling/reload logic that could explain it.

### Files Changed

- `packages/embedded-connection-journey/src/iframe-overlay.ts`
- `packages/embedded-connection-journey/src/journey.ts`

### Key Changes

- `IframeOverlay.create()` no longer sets `iframe.src` — the URL is stashed as `pendingSrc` instead.
- Added `IframeOverlay.load()`, which assigns `iframe.src` from `pendingSrc` exactly once.
- `Journey.start()` now calls `overlay.load()` before `overlay.show()`, so the iframe only fetches the connection URL when the journey is actually started.

### Notable Items

- No public API changes — `createJourney`/`start`/`close`/`remove`/`status` signatures are unchanged.
- `MessageHandler` was checked and is unaffected: it reads `iframeWindow.contentWindow` dynamically at message time and `startListening()` was already gated on `.start()`, so deferring `src` assignment doesn't disturb message handling.
- Existing test suite (9 tests) passes unmodified; type-check and lint are clean.
- This fix does not auto-propagate to existing partner integrations: npm consumers need to bump their dependency and redeploy, and CDN consumers (`data.one/external/assets/...`) are served from a manually-committed static asset in `data-one-website`, requiring a separate manual update + deploy there.


[DATA1-3661]: https://clearscore.atlassian.net/browse/DATA1-3661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Deferred iframe network load until journey.start() was invoked


<sup>[More info](https://app.aikido.dev/featurebranch/scan/143200479?groupId=70466)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->